### PR TITLE
Adds UDS and a no-stdout mode with builtin throughput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,18 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+
+[profile.release]
+debug=true
+
+
 [lib]
 name         = "helloRust"
-crate-type   = ["rlib", "cdylib"] 
+crate-type   = ["rlib", "cdylib"]
 
 [[bin]]
 name = "helloRust"
 path = "src/bin.rs"
-
 
 [dependencies]
 libc = "0.2"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/benthosdev/benthos/v4 v4.10.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
@@ -20,6 +21,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opentelemetry.io/otel v1.9.0 // indirect
 	go.opentelemetry.io/otel/trace v1.9.0 // indirect
+	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/net v0.0.0-20220927171203-f486391704dc // indirect
 	golang.org/x/text v0.3.8 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd3
 github.com/benthosdev/benthos/v4 v4.10.0 h1:h29PkxAxed44HX9YOyo0JxqfJtOYQt1XfNDQK/lYC1A=
 github.com/benthosdev/benthos/v4 v4.10.0/go.mod h1:MRv2pOKbXHD15MgfrgJI6ZeckOFA4XaP7iHm1g9JsF8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -40,6 +42,8 @@ go.opentelemetry.io/otel v1.9.0 h1:8WZNQFIB2a71LnANS9JeyidJKKGOOremcUtb/OtHISw=
 go.opentelemetry.io/otel v1.9.0/go.mod h1:np4EoPGzoPs3O67xUVNoPPcmSvsfOxNlNA4F4AC+0Eo=
 go.opentelemetry.io/otel/trace v1.9.0 h1:oZaCNJUjWcg60VXWee8lJKlqhPbXAPB51URuR47pQYc=
 go.opentelemetry.io/otel/trace v1.9.0/go.mod h1:2737Q0MuG8q1uILYm2YYVkAyLtOofiTNGg6VODnOiPo=
+go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
+go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 golang.org/x/net v0.0.0-20220927171203-f486391704dc h1:FxpXZdoBqT8RjqTy6i1E8nXHhW21wK7ptQ/EPIGxzPQ=
 golang.org/x/net v0.0.0-20220927171203-f486391704dc/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=

--- a/helloRust.h
+++ b/helloRust.h
@@ -1,4 +1,5 @@
 
 char* transform(char* str);
 char* passthrough(char* str);
+char* noop(char* str);
 char* transform_vrl(char* str);

--- a/helloRust.h
+++ b/helloRust.h
@@ -1,5 +1,4 @@
 
 char* transform(char* str);
-char* passthrough(char* str);
 char* noop(char* str);
 char* transform_vrl(char* str);

--- a/main.go
+++ b/main.go
@@ -12,42 +12,152 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"log"
+	"net"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
+	"time"
 	"unsafe"
 
 	"github.com/benthosdev/benthos/v4/public/bloblang"
+	"github.com/dustin/go-humanize"
+	"go.uber.org/atomic"
 )
+
+const (
+	sockAddr = "/tmp/cgo.sock"
+)
+
+func getUdsReader() *bufio.Reader {
+	if _, err := os.Stat(sockAddr); err == nil {
+		if err := os.RemoveAll(sockAddr); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	listener, err := net.Listen("unix", sockAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Print("Waiting for connection...")
+	conn, err := listener.Accept()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Print("Accepted connection from ", conn.RemoteAddr().Network())
+
+	return bufio.NewReader(conn)
+}
+
+type throughputRecorder struct {
+	start      time.Time
+	totalBytes atomic.Float64
+}
+
+func (tr *throughputRecorder) Record(nBytes int) {
+	if time.Time.IsZero(tr.start) {
+		tr.start = time.Now()
+	}
+	tr.totalBytes.Add(float64(nBytes))
+}
+
+func (tr *throughputRecorder) AvgThroughput() string {
+	now := time.Now()
+
+	elapsed := now.Sub(tr.start)
+	avgBytes := uint64(tr.totalBytes.Load() / elapsed.Seconds())
+	return fmt.Sprintf("%s / second", humanize.Bytes(avgBytes))
+}
+
+func getBlackholeWriter(tr *throughputRecorder) func(a ...any) (int, error) {
+
+	blackhole := func(a ...any) (int, error) {
+		s := a[0].(string)
+		l := len(s)
+		tr.Record(l)
+		return l, nil
+	}
+
+	return blackhole
+}
+
+type OutFunc func(a ...any) (int, error)
 
 func main() {
 
 	rust := flag.Bool("rust", false, "use rust")
+	noopRust := flag.Bool("nooprust", false, "use no-op rust")
+	noopGo := flag.Bool("noopgo", false, "use no-op go")
 	vrl := flag.Bool("vrl", false, "use vrl")
+	stdout := flag.Bool("stdout", false, "Output to stdout")
 	useBloblang := flag.Bool("bloblang", false, "use bloblang")
+	useUds := flag.Bool("uds", false, "accept data from UDS")
 	flag.Parse()
 
-	reader := bufio.NewReader(os.Stdin)
+	var reader *bufio.Reader
+	if *useUds {
+		reader = getUdsReader()
+	} else {
+		reader = bufio.NewReader(os.Stdin)
+	}
 
 	var exe *bloblang.Executor
 	if *useBloblang {
 		exe = setupBloblang()
 	}
 
+	var output OutFunc
+	if *stdout {
+		output = fmt.Println
+	} else {
+		throughputRecorder := throughputRecorder{}
+		output = getBlackholeWriter(&throughputRecorder)
+		go func() {
+			oneSecond, err := time.ParseDuration("1s")
+			if err != nil {
+				panic(err)
+			}
+
+			for {
+				time.Sleep(oneSecond)
+				fmt.Println(throughputRecorder.AvgThroughput())
+			}
+		}()
+	}
+
 	for {
 		text, _ := reader.ReadString('\n')
 		if *rust {
-			fmt.Println(processStringRs(text))
+			output(processStringRs(text))
 		} else if *vrl {
 			text = strings.TrimSpace(text)
 			text = fmt.Sprintf("{\"message\":\"%s\"}", text)
-			fmt.Println(processStringVrl(text))
+			output(processStringVrl(text))
 		} else if *useBloblang {
-			fmt.Println(processStringBloblang(exe, text))
+			output(processStringBloblang(exe, text))
+		} else if *noopRust {
+			output(noopStringRs(text))
+		} else if *noopGo {
+			output(simpleStringGo(text))
 		} else {
-			fmt.Println(processStringGo(text))
+			output(processStringGo(text))
 		}
+
+		runtime.Gosched()
 	}
+}
+
+func noopStringRs(str string) string {
+	cs := C.CString(str)
+	b := C.noop(cs)
+	s := C.GoString(b)
+	defer C.free(unsafe.Pointer(cs))
+	defer C.free(unsafe.Pointer(b))
+	return s
 }
 
 func processStringRs(str string) string {

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
-//#cgo CFLAGS: -I./target/release/
-//#cgo LDFLAGS: -L./target/release -lhelloRust
+//#cgo CFLAGS: -I${SRCDIR}/target/release/
+//#cgo LDFLAGS: -L${SRCDIR}/target/release -Wl,-rpath=${SRCDIR}/target/release -lhelloRust
 //
 //#include <stdio.h>
 //#include <stdlib.h>
 //#include <string.h>
-//#include <helloRust.h>
+//#include "helloRust.h"
 import "C"
 import (
 	"bufio"
@@ -182,15 +182,6 @@ var r = regexp.MustCompile(`\b\w{4}\b`)
 
 func processStringGo(str string) string {
 	return r.ReplaceAllString(str, "gogo")
-}
-
-func simpleStringRs(str string) string {
-	cs := C.CString(str)
-	b := C.passthrough(cs)
-	s := C.GoString(b)
-	defer C.free(unsafe.Pointer(cs))
-	defer C.free(unsafe.Pointer(b))
-	return s
 }
 
 // Copy a string

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 cargo build --release
-RUST_BACKTRACE=1 go run . -vrl
+RUST_BACKTRACE=1 go run . -vrl -stdout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,13 @@
-
-
+use ::value::{Secrets, Value};
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::ffi::CStr;
 use std::ffi::CString;
-use regex::Regex;
-use lazy_static::lazy_static;
-use ::value::{Secrets, Value};
 use vrl::Program;
 use vrl::TimeZone;
-use std::collections::BTreeMap;
 use vrl::{state, Runtime, TargetValueRef};
-use std::cell::RefCell;
-
 
 lazy_static! {
     static ref RE: Regex = Regex::new(r"\b\w{4}\b").unwrap();
@@ -21,7 +18,7 @@ thread_local! {static RUNTIME: RefCell<Runtime> = RefCell::new(Runtime::new(stat
 
 pub fn compile_vrl() -> Program {
     // let program = r#"."#;
-    let program = r#". = replace(string!(.), r'\b\w{4}\b', "rust")"#;
+    let program = r#". = replace(string!(.), r'\b\w{4}\b', "rust", 1)"#;
     return vrl::compile(&program, &vrl_stdlib::all()).unwrap().program;
 }
 
@@ -37,10 +34,12 @@ pub fn run_vrl(s: &str) -> String {
 
     let output = RUNTIME.with(|r| {
         // r.borrow_mut().clear();
-        return  r.borrow_mut().resolve(&mut target, &VRL_PROGRAM, &TimeZone::Local);
+        return r
+            .borrow_mut()
+            .resolve(&mut target, &VRL_PROGRAM, &TimeZone::Local);
     });
-    
-    return output.unwrap().to_string()
+
+    return output.unwrap().to_string();
 }
 
 #[no_mangle]
@@ -48,6 +47,13 @@ pub extern "C" fn transform(input: *const libc::c_char) -> *const libc::c_char {
     let inpt: &CStr = unsafe { CStr::from_ptr(input) };
     let replaced = RE.replace(inpt.to_str().unwrap(), "rust");
     let c_str = CString::new(replaced.as_bytes()).expect("CString::new failed");
+    return c_str.into_raw();
+}
+
+#[no_mangle]
+pub extern "C" fn noop(input: *const libc::c_char) -> *const libc::c_char {
+    let inpt: &CStr = unsafe { CStr::from_ptr(input) };
+    let c_str = CString::new(inpt.to_str().unwrap()).expect("CString::new failed");
     return c_str.into_raw();
 }
 
@@ -65,7 +71,5 @@ pub extern "C" fn passthrough(input: *const libc::c_char) -> *const libc::c_char
     let rust_str = inpt.to_str().unwrap().to_string();
     let c_str = CString::new(rust_str).expect("CString::new failed");
 
-    
     return c_str.into_raw();
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run_vrl(s: &str) -> String {
 #[no_mangle]
 pub extern "C" fn transform(input: *const libc::c_char) -> *const libc::c_char {
     let inpt: &CStr = unsafe { CStr::from_ptr(input) };
-    let replaced = RE.replace(inpt.to_str().unwrap(), "rust");
+    let replaced = RE.replacen(inpt.to_str().unwrap(), 1, "rust");
     let c_str = CString::new(replaced.as_bytes()).expect("CString::new failed");
     return c_str.into_raw();
 }
@@ -62,14 +62,5 @@ pub extern "C" fn transform_vrl(input: *const libc::c_char) -> *const libc::c_ch
     let inpt: &CStr = unsafe { CStr::from_ptr(input) };
     let output = run_vrl(inpt.to_str().unwrap());
     let c_str = CString::new(output.as_bytes()).expect("CString::new failed");
-    return c_str.into_raw();
-}
-
-#[no_mangle]
-pub extern "C" fn passthrough(input: *const libc::c_char) -> *const libc::c_char {
-    let inpt: &CStr = unsafe { CStr::from_ptr(input) };
-    let rust_str = inpt.to_str().unwrap().to_string();
-    let c_str = CString::new(rust_str).expect("CString::new failed");
-
     return c_str.into_raw();
 }

--- a/test-go-50mb.sh
+++ b/test-go-50mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 50000 | go run . | pv > /dev/null
+./flog -l -b 1024 -r 50000 | go run .

--- a/test-go-5mb.sh
+++ b/test-go-5mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 5000 | go run . | pv > /dev/null
+./flog -l -b 1024 -r 5000 | go run .

--- a/test-rust-50mb.sh
+++ b/test-rust-50mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 50000 | go run . -rust | pv > /dev/null
+./flog -l -b 1024 -r 50000 | go run . -rust

--- a/test-rust-5mb.sh
+++ b/test-rust-5mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 5000 | go run . -rust | pv > /dev/null
+./flog -l -b 1024 -r 5000 | go run . -rust

--- a/test-vrl-50mb.sh
+++ b/test-vrl-50mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 50000 | go run . -vrl | pv > /dev/null
+./flog -l -b 1024 -r 50000 | go run . -vrl

--- a/test-vrl-5mb.sh
+++ b/test-vrl-5mb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash 
+#!/bin/bash
 cargo build --release
-./flog -l -b 1024 -r 5000 | go run . -vrl | pv > /dev/null
+./flog -l -b 1024 -r 5000 | go run . -vrl


### PR DESCRIPTION
Are you interested in any of these changes, I can break up into smaller commits no problem.

- Accept incoming data via UDS
- Don't output to stdout by default and instead use very basic throughput printer
- noop rust mode
- rustfmt changes
- rust `replace` -> `replacen`

